### PR TITLE
Fix android Error while merging dex archives

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "com.reactlibrary"
+        group = "com.reactlibrary.DeviceConstants"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ def configureReactNativePom(def pom) {
         name packageJson.title
         artifactId packageJson.name
         version = packageJson.version
-        group = "com.reactlibrary.DeviceConstants"
+        group = "com.reactlibrary.deviceconstants"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.reactlibrary.DeviceConstants">
 
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary.DeviceConstants">
+          package="com.reactlibrary.deviceconstants">
 
 </manifest>

--- a/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsModule.java
+++ b/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.reactlibrary.DeviceConstants;
 
 import android.app.UiModeManager;
 import android.content.Context;

--- a/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsModule.java
+++ b/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.DeviceConstants;
+package com.reactlibrary.deviceconstants;
 
 import android.app.UiModeManager;
 import android.content.Context;

--- a/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsPackage.java
+++ b/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsPackage.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.DeviceConstants;
+package com.reactlibrary.deviceconstants;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsPackage.java
+++ b/android/src/main/java/com/reactlibrary/DeviceConstants/DeviceConstantsPackage.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.reactlibrary.DeviceConstants;
 
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Fixes duplicate com.reactlibrary issues when building with D8

```
AGPBI: {"kind":"error","text":"Program type already present: com.reactlibrary.BuildConfig","sources":[{}],"tool":"D8"}
com.android.builder.dexing.DexArchiveMergerException: Error while merging dex archives: 
Learn how to resolve the issue at https://developer.android.com/studio/build/dependencies#duplicate_classes.
Program type already present: com.reactlibrary.BuildConfig
	at com.android.builder.dexing.D8DexArchiveMerger.getExceptionToRethrow(D8DexArchiveMerger.java:131)
	at com.android.builder.dexing.D8DexArchiveMerger.mergeDexArchives(D8DexArchiveMerger.java:118)
	at com.android.build.gradle.internal.transforms.DexMergerTransformCallable.call(DexMergerTransformCallable.java:102)
	at com.android.build.gradle.internal.tasks.DexMergingTaskRunnable.run(DexMergingTask.kt:444)
	at com.android.build.gradle.internal.tasks.Workers$ActionFacade.run(Workers.kt:335)```